### PR TITLE
feat: Parent Stack Addition (PIQ-44)

### DIFF
--- a/website/iac/cfn/codestar/s3-website-git-sync-parent.yaml
+++ b/website/iac/cfn/codestar/s3-website-git-sync-parent.yaml
@@ -1,0 +1,20 @@
+Description: "Parent Stack for S3 Website Template Git Sync Configuration (v1.0.0)"
+Parameters:
+  SuggestedStackName:
+    Type: "String"
+    Description: "If creating through the AWS Console, this is the suggested stack name.  Copy and paste this value for the stack name."
+    Default: "WebsiteGitSync"
+Resources:
+  GitSyncSetupWaitCondition:
+    Type: "AWS::CloudFormation::WaitConditionHandle"
+Metadata:
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+    - Label:
+        default: "General Configuration"
+      Parameters:
+      - SuggestedStackName
+    ParameterLabels:
+      # General Configuration
+      SuggestedStackName:
+        default: "Suggested Stack Name:"

--- a/website/iac/cfn/codestar/sync-configuration-s3-website.yaml
+++ b/website/iac/cfn/codestar/sync-configuration-s3-website.yaml
@@ -15,8 +15,8 @@ Parameters:
     Default: "/website/deployment/s3/website.yaml"
   ResourceName:
     Type: "String"
-    Description: "The name to give this configuration."
-    Default: "sync-configuration-s3-website"
+    Description: "The name of the parent stack."
+    Default: "WebsiteGitSync" #Must match the name of the parent template stack.
 Resources:
   GitHubSyncConfiguration:
     Type: "AWS::CodeStarConnections::SyncConfiguration"
@@ -27,6 +27,12 @@ Resources:
       ConfigFile: !Ref ConfigFile
       ResourceName: !Ref ResourceName
       SyncType: "CFN_STACK_SYNC"
+Outputs:
+  GitHubSyncConfigurationArn:
+    Description: "The Git Sync Configuration ARN."
+    Value: !Ref GitHubSyncConfiguration
+    Export:
+      Name: !Sub "${AWS::StackName}-GitHubSyncConfigurationArn"
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:

--- a/website/iac/cfn/iam/role/git-sync.yaml
+++ b/website/iac/cfn/iam/role/git-sync.yaml
@@ -20,6 +20,7 @@ Resources:
         - Effect: "Allow"
           Principal:
             Service:
+            - "cloudformation.amazonaws.com" #Need to determine if this is really required.
             - "cloudformation.sync.codeconnections.amazonaws.com"
           Action:
           - "sts:AssumeRole"

--- a/website/iac/cfn/s3/website.yaml
+++ b/website/iac/cfn/s3/website.yaml
@@ -18,7 +18,7 @@ Resources:
       AccessControl: "PublicRead"
       OwnershipControls:
         Rules:
-        - ObjectOwnership: "BucketOwnerEnforced"
+        - ObjectOwnership: "BucketOwnerPreferred"
       VersioningConfiguration:
         Status: "Suspended"
       WebsiteConfiguration:


### PR DESCRIPTION
It turns out that you need a blank Stack that the Git Sync configuration can be attached to.  It is a little odd how this was all done, and because of this oddity, doing this via multple stacks is barely better than ClickOps.

The only thing that makes this any better than ClickOps is the fact that you elimiate human error.