### PR TITLE
fix: Making the bucket public (PIQ-44)

### DIFF
--- a/website/iac/cfn/s3/website.yaml
+++ b/website/iac/cfn/s3/website.yaml
@@ -19,6 +19,11 @@ Resources:
       OwnershipControls:
         Rules:
         - ObjectOwnership: "BucketOwnerPreferred"
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: false
+        BlockPublicPolicy: false
+        IgnorePublicAcls: false
+        RestrictPublicBuckets: false
       VersioningConfiguration:
         Status: "Suspended"
       WebsiteConfiguration:


### PR DESCRIPTION
Since this is just going to host a simple site, it is okay that the contents are public.  The contents are already public anyway on GitHub.